### PR TITLE
LUGG-951 Added validation for postal code dash

### DIFF
--- a/luggage_people_isu.module
+++ b/luggage_people_isu.module
@@ -19,7 +19,7 @@ function luggage_people_isu_node_presave($node) {
   // Respond only to new nodes of type 'people' with street address.
   if (isset($node->is_new) && $node->type == 'people') {
     // ZIP+4 formatting: 500113222 becomes 50011-3222
-    if (isset($node->field_people_postal[LANGUAGE_NONE][0]['value']) && !strpos($node->field_people_postal[LANGUAGE_NONE][0]['value'], '-')) {
+    if (isset($node->field_people_postal[LANGUAGE_NONE][0]['value']) && !strpos($node->field_people_postal[LANGUAGE_NONE][0]['value'], '-') && strlen($node->field_people_postal[LANGUAGE_NONE][0]['value']) == 9) {
       $node->field_people_postal[LANGUAGE_NONE][0]['value'] = str_replace('50011', '50011-', $node->field_people_postal[LANGUAGE_NONE][0]['value']);
     }
   }


### PR DESCRIPTION
Postal codes would automatically get a dash when they were only 5 digits long.

Testing:
- Pull down changes
In a people profile page:
- Make a postal code with exactly 5 digits, see if it gets a dash
- Make a postal code with between 6-8 digits, see if it gets a dash
- Make a postal code with 9 digits, see if it gets a dash
- Make a postal code with actual 10 digit format (xxxxx-xxxx), see if it gets another dash